### PR TITLE
chore: Disable music link event listener

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,11 +37,8 @@ import EventEmitter from 'events';
   ],
   providers: NestClassCollection.fromInjectables(providers)
     .concat(NestClassCollection.fromInjectables(commands))
-    .concat(
-      NestClassCollection.fromInjectables(handlers).except(
-        handlers.MusicLinkHandler,
-      ),
-    )
+    .concat(NestClassCollection.fromInjectables(handlers))
+    .except(handlers.MusicLinkHandler)
     .toArray(),
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,7 +37,11 @@ import EventEmitter from 'events';
   ],
   providers: NestClassCollection.fromInjectables(providers)
     .concat(NestClassCollection.fromInjectables(commands))
-    .concat(NestClassCollection.fromInjectables(handlers))
+    .concat(
+      NestClassCollection.fromInjectables(handlers).except(
+        handlers.MusicLinkHandler,
+      ),
+    )
     .toArray(),
 })
 export class AppModule {}


### PR DESCRIPTION
Disables the event listener that triggers the music-link feature of Norsk-bott.
Temporary measure while figuring out a way to provide this feature in a less invasive manner.

disclaimer: i know very little about the codebase here, but removing the export seemed to do the trick for DI not to be able to include it anymore :shrug: 

Did a poll in #server-suggestions on NLL after a new request to remove the music linking feature from a user. Majority believes that the aspect of how the bot links various music services can be improved, to be e.g. a message sent upon request (ephemerally). 