### PR TITLE
fix: Changed formatting of `sync` sub-command status texts to use sub…

### DIFF
--- a/src/commands/discourse/sync.command.ts
+++ b/src/commands/discourse/sync.command.ts
@@ -22,12 +22,6 @@ import {
 } from '../../providers/index.js';
 import { createi18n } from '../../utils/create-i18n.js';
 
-const norwegianTime = new Intl.DateTimeFormat('no-NO', {
-  timeZone: 'Europe/Oslo',
-  dateStyle: 'long',
-  timeStyle: 'long',
-});
-
 interface Result {
   success: boolean;
   message?: string;
@@ -460,13 +454,11 @@ export class DiscourseSyncSubCommand {
     // new message
 
     const messages: string[] = [];
-    const now = new Date();
+    const unixTimestamp = Math.floor(new Date().getTime() / 1000);
 
     let currentMessage = '';
 
-    content += `\n\nPage ID: ${hash}\nLast synced by ${user} at ${norwegianTime.format(
-      now,
-    )}`;
+    content += `\n\n-# Page ID: ${hash}\n-# Last synced by ${user} at <t:${unixTimestamp}>`;
 
     const lines = content.split('\n');
 

--- a/src/commands/notion/sync.command.ts
+++ b/src/commands/notion/sync.command.ts
@@ -20,12 +20,6 @@ import {
   SyncPage,
 } from '../../providers/index.js';
 
-const norwegianTime = new Intl.DateTimeFormat('no-NO', {
-  timeZone: 'Europe/Oslo',
-  dateStyle: 'long',
-  timeStyle: 'long',
-});
-
 interface Result {
   success: boolean;
   message?: string;
@@ -404,13 +398,11 @@ export class SyncSubCommand {
     // new message
 
     const messages: string[] = [];
-    const now = new Date();
+    const unixTimestamp = Math.floor(new Date().getTime() / 1000);
 
     let currentMessage = '';
 
-    content += `\n\nPage ID: ${hash}\nLast synced by ${user} at ${norwegianTime.format(
-      now,
-    )}`;
+    content += `\n\n-# Page ID: ${hash}\n-# Last synced by ${user} at <t:${unixTimestamp}>`;
 
     const lines = content.split('\n');
 


### PR DESCRIPTION
…text and timestamps.

The Page ID and Last synced by lines have been changed from normal text to subtext. This makes the text more separate from the actual content that is being synced, and keeps meta-information more separate.

The date in the Last synced by line has been changed to utilise Discord's date/time formatting, allowing us to display time in the current time zone for any viewer.